### PR TITLE
Update Streams

### DIFF
--- a/fable/Fable.Import.Node.PowerPack.fsproj
+++ b/fable/Fable.Import.Node.PowerPack.fsproj
@@ -2,8 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="Meta.props" />
   <PropertyGroup>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <TargetFramework>netstandard2.0</TargetFramework>
+     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Stream.fs" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -3,9 +3,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.36",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.36.tgz",
-      "integrity": "sha512-sW77BFwJ48YvQp3Gzz5xtAUiXuYOL2aMJKDwiaY3OcvdqBFurtYfOpSa4QrNyDxmOGRFSYzUpabU2m9QrlWE7w==",
+      "version": "7.0.0-beta.37",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.37.tgz",
+      "integrity": "sha512-LIpcKm+2otOOvOvhCbD6wkNYi8aUwHk73uWR+hxBdW2EFht5D0QX89n4me8nyeNGWr5zC3Pvmjq+9MvUof+jkg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
@@ -45,9 +45,9 @@
       }
     },
     "@types/node": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.2.tgz",
-      "integrity": "sha512-KA4GKOpgXnrqEH2eCVhiv2CsxgXGQJgV1X0vsGlh+WCnxbeAE1GT44ZsTU1IN5dEeV/gDupKa7gWo08V5IxWVQ==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
+      "integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw==",
       "dev": true
     },
     "abab": {
@@ -896,13 +896,6 @@
         "tweetnacl": "0.14.5"
       }
     },
-    "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
-      "dev": true,
-      "optional": true
-    },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
@@ -1361,6 +1354,12 @@
         "strip-eof": "1.0.0"
       }
     },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
     "expand-brackets": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
@@ -1380,17 +1379,17 @@
       }
     },
     "expect": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-22.0.3.tgz",
-      "integrity": "sha512-QapzeQkcA3jCx4pDnD07I4SPPxScKbey8TD/WwrnzmpHmL5q0dUtXfUt5OIFOjVBCg+C4zn4Y1zK9Rb9SIDL1g==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-22.1.0.tgz",
+      "integrity": "sha512-8K+8TjNnZq73KYtqNWKWTbYbN8z4loeL+Pn2bqpmtTdBtLNXJtpz9vkUcQlFsgKMDRA3VM8GXRA6qbV/oBF7Bw==",
       "dev": true,
       "requires": {
         "ansi-styles": "3.2.0",
-        "jest-diff": "22.0.3",
-        "jest-get-type": "22.0.3",
-        "jest-matcher-utils": "22.0.3",
-        "jest-message-util": "22.0.3",
-        "jest-regex-util": "22.0.3"
+        "jest-diff": "22.1.0",
+        "jest-get-type": "22.1.0",
+        "jest-matcher-utils": "22.1.0",
+        "jest-message-util": "22.1.0",
+        "jest-regex-util": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -2661,6 +2660,16 @@
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
     },
+    "import-local": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+      "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
+      }
+    },
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -2726,9 +2735,9 @@
       "dev": true
     },
     "is-ci": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
-      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
         "ci-info": "1.1.2"
@@ -2777,13 +2786,16 @@
       }
     },
     "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-generator-fn": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+      "integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+      "dev": true
     },
     "is-glob": {
       "version": "2.0.1",
@@ -2987,12 +2999,12 @@
       }
     },
     "jest": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-22.0.4.tgz",
-      "integrity": "sha512-S0tmgK5psULvt/11QzgAZWGpY5y5TkMRzd3T21Q13JzTx37Vx6F0Nw022c9Kc/IbEy+AHkKkGFVO5QafE8MrDg==",
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-22.1.1.tgz",
+      "integrity": "sha512-yOYSMzTqgWcNKSM1ctOJxHXKWndejSD9EtsDb4Wfvqc6Fc+qX4KJ6Dgm2oKvkjKSS6o8Gax1ykQWXxEhv8R7+Q==",
       "dev": true,
       "requires": {
-        "jest-cli": "22.0.4"
+        "jest-cli": "22.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3022,42 +3034,44 @@
           }
         },
         "jest-cli": {
-          "version": "22.0.4",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.0.4.tgz",
-          "integrity": "sha512-f1lZRM13IwIINzjE3RebXQKtQLiKncpSrbJZ/aTZJXmzEWGdgSayW4ESyhU+xK3uGiJEUSzbHjwPY6nGJ8VbUA==",
+          "version": "22.1.1",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-22.1.1.tgz",
+          "integrity": "sha512-QFnt/p+iJFrAKe9rM4D3L2Rw8ckN9kOAQe8jfUZ43gTA99IMDfteub6bDqUAOzzWxRo1aHNDicwGuqqWHdw0yg==",
           "dev": true,
           "requires": {
             "ansi-escapes": "3.0.0",
             "chalk": "2.3.0",
+            "exit": "0.1.2",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
-            "is-ci": "1.0.10",
+            "import-local": "1.0.0",
+            "is-ci": "1.1.0",
             "istanbul-api": "1.2.1",
             "istanbul-lib-coverage": "1.1.1",
             "istanbul-lib-instrument": "1.9.1",
             "istanbul-lib-source-maps": "1.2.2",
-            "jest-changed-files": "22.0.3",
-            "jest-config": "22.0.4",
-            "jest-environment-jsdom": "22.0.4",
-            "jest-get-type": "22.0.3",
-            "jest-haste-map": "22.0.3",
-            "jest-message-util": "22.0.3",
-            "jest-regex-util": "22.0.3",
-            "jest-resolve-dependencies": "22.0.3",
-            "jest-runner": "22.0.4",
-            "jest-runtime": "22.0.4",
-            "jest-snapshot": "22.0.3",
-            "jest-util": "22.0.4",
-            "jest-worker": "22.0.3",
+            "jest-changed-files": "22.1.0",
+            "jest-config": "22.1.1",
+            "jest-environment-jsdom": "22.1.0",
+            "jest-get-type": "22.1.0",
+            "jest-haste-map": "22.1.0",
+            "jest-message-util": "22.1.0",
+            "jest-regex-util": "22.1.0",
+            "jest-resolve-dependencies": "22.1.0",
+            "jest-runner": "22.1.1",
+            "jest-runtime": "22.1.1",
+            "jest-snapshot": "22.1.0",
+            "jest-util": "22.1.0",
+            "jest-worker": "22.1.0",
             "micromatch": "2.3.11",
-            "node-notifier": "5.1.2",
+            "node-notifier": "5.2.1",
             "realpath-native": "1.0.0",
             "rimraf": "2.6.2",
             "slash": "1.0.0",
             "string-length": "2.0.0",
             "strip-ansi": "4.0.0",
             "which": "1.3.0",
-            "yargs": "10.0.3"
+            "yargs": "10.1.1"
           }
         },
         "strip-ansi": {
@@ -3081,31 +3095,31 @@
       }
     },
     "jest-changed-files": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.0.3.tgz",
-      "integrity": "sha512-CG7eNJNO9x1O/3J4Uhe2QXra1MnC9+KS1f2NeOg+7iQ+8dDCgxCtpusmKfu44TnEyKwkIDhDr6htPfPaI+Fwbw==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-22.1.0.tgz",
+      "integrity": "sha512-NGc5HF3zXaMMph1L3HwPw7zVu0uAad2CZ+5QYQaP9QzB9jBioukulg2vcy7gdJRfWAr3D8EGlu4jfUHOtLNVmQ==",
       "dev": true,
       "requires": {
         "throat": "4.1.0"
       }
     },
     "jest-config": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.0.4.tgz",
-      "integrity": "sha512-NcBeixqHjHDZO9+pUj+365LQV2s65d2f0/IrwlUyv0xaJovRNc6eDvoJ/r2UUlHnqjP3Go+R0ECUsXPXjk4SHw==",
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-22.1.1.tgz",
+      "integrity": "sha512-imzke/YkKXOQKec5cvprqvfcWKNGccZCs3dDk8wTGaqeFnGsx9A9csZ7zzGMlMG8qjlnl+/urRjIdk8XZEXuUg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "glob": "7.1.2",
-        "jest-environment-jsdom": "22.0.4",
-        "jest-environment-node": "22.0.4",
-        "jest-get-type": "22.0.3",
-        "jest-jasmine2": "22.0.4",
-        "jest-regex-util": "22.0.3",
-        "jest-resolve": "22.0.4",
-        "jest-util": "22.0.4",
-        "jest-validate": "22.0.3",
-        "pretty-format": "22.0.3"
+        "jest-environment-jsdom": "22.1.0",
+        "jest-environment-node": "22.1.0",
+        "jest-get-type": "22.1.0",
+        "jest-jasmine2": "22.1.1",
+        "jest-regex-util": "22.1.0",
+        "jest-resolve": "22.1.0",
+        "jest-util": "22.1.0",
+        "jest-validate": "22.1.0",
+        "pretty-format": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3140,15 +3154,15 @@
       }
     },
     "jest-diff": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.0.3.tgz",
-      "integrity": "sha512-Y7xN9Lc/NgFvR14lvjrJXB6x2x1LLe5NnMyzLvilBSSOyjy9uAVnR2Bt1YgzdfRrfaxsx7xFUVcqXLUnPkrJcA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-22.1.0.tgz",
+      "integrity": "sha512-lowdbU/dzXh+2/MR5QcvU5KPNkO4JdAEYw0PkQCbIQIuy5+g3QZBuVhWh8179Fmpg4CQrz1WgoK/yQHDCHbqqw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
         "diff": "3.4.0",
-        "jest-get-type": "22.0.3",
-        "pretty-format": "22.0.3"
+        "jest-get-type": "22.1.0",
+        "pretty-format": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3183,33 +3197,33 @@
       }
     },
     "jest-docblock": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.0.3.tgz",
-      "integrity": "sha512-LhviP2rqIg2IzS6m97W7T032oMrT699Tr6Njjhhl4FCLj+75BUy9CsSmGgfoVEql1uc+myBkssvcbn7T9xDR+A==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-22.1.0.tgz",
+      "integrity": "sha512-/+OGgBVRJb5wCbXrB1LQvibQBz2SdrvDdKRNzY1gL+OISQJZCR9MOewbygdT5rVzbbkfhC4AR2x+qWmNUdJfjw==",
       "dev": true,
       "requires": {
         "detect-newline": "2.1.0"
       }
     },
     "jest-environment-jsdom": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.0.4.tgz",
-      "integrity": "sha512-vnjefLZlsNsmnjKcaXkx2IxTBNG40vfRVOdMfcfkPkq85JxFB7wzNtjLx+RIfiNpIZd04C1PXbF0aJIenY85Ng==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-22.1.0.tgz",
+      "integrity": "sha512-2R+LlFG+r9l0QK1fb7ywOxrBLu/aC8otBaRRMzPHf3binuumng61g3LxaXhEYstGvMPukMtkVRvX0X6J3wRCqg==",
       "dev": true,
       "requires": {
-        "jest-mock": "22.0.3",
-        "jest-util": "22.0.4",
+        "jest-mock": "22.1.0",
+        "jest-util": "22.1.0",
         "jsdom": "11.5.1"
       }
     },
     "jest-environment-node": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.0.4.tgz",
-      "integrity": "sha512-9vjNKb86UivvKCZCudMNixQgdMnOG7ql6iVYnaiK0CmvZ0WQD+mlM10NvgiWpRv4HstcnRL1pY/GSIHXAD6qXw==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-22.1.0.tgz",
+      "integrity": "sha512-dJnTuEyCUsoY7BE9PbtSxBDkj888VhXUv6Z6yF2OUqJVPLcutiXdBW5luecmNSuKtZ6mMNF+tZBj+iQ2frWslg==",
       "dev": true,
       "requires": {
-        "jest-mock": "22.0.3",
-        "jest-util": "22.0.4"
+        "jest-mock": "22.1.0",
+        "jest-util": "22.1.0"
       }
     },
     "jest-fable-preprocessor": {
@@ -3240,39 +3254,41 @@
       }
     },
     "jest-get-type": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.0.3.tgz",
-      "integrity": "sha512-TaJnc/lnJQ3jwry+NUWkqaJmKrM/Ut3XdK89HfiqdI3DMRLd6Zb4wyKjwuNP37MEQqlNg0YWH4sbBR8D4exjCA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.1.0.tgz",
+      "integrity": "sha512-nD97IVOlNP6fjIN5i7j5XRH+hFsHL7VlauBbzRvueaaUe70uohrkz7pL/N8lx/IAwZRTJ//wOdVgh85OgM7g3w==",
       "dev": true
     },
     "jest-haste-map": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.0.3.tgz",
-      "integrity": "sha512-VosIMOFQFu1rTF+MvOWVuv2KVmZ9eTkRgfwW2yUAs6/AhwmIfXRl/tih+fIOYcHzU4Auu1G8Fvl2kkF5g0k6/A==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-22.1.0.tgz",
+      "integrity": "sha512-vETdC6GboGlZX6+9SMZkXtYRQSKBbQ47sFF7NGglbMN4eyIZBODply8rlcO01KwBiAeiNCKdjUyfonZzJ93JEg==",
       "dev": true,
       "requires": {
         "fb-watchman": "2.0.0",
         "graceful-fs": "4.1.11",
-        "jest-docblock": "22.0.3",
-        "jest-worker": "22.0.3",
+        "jest-docblock": "22.1.0",
+        "jest-worker": "22.1.0",
         "micromatch": "2.3.11",
         "sane": "2.2.0"
       }
     },
     "jest-jasmine2": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.0.4.tgz",
-      "integrity": "sha512-pn1XPHUkffHK6oNY1Dfl/+Rg0UuTdlg3aGDnjyK6dZzGEBeiH1uKuSgZEjy3Lj461l3atpzsQyw7ilXPyjFnUw==",
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-22.1.1.tgz",
+      "integrity": "sha512-AkDEBKTDFU8yKrm+6Gx7uHo++LgcfzRry+mh+/BCy0kxyNxuz+iJSFS2zfW0zpc/LcJONTCTfcNOT1qJ59I3Ow==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.3.0",
-        "expect": "22.0.3",
+        "co": "4.6.0",
+        "expect": "22.1.0",
         "graceful-fs": "4.1.11",
-        "jest-diff": "22.0.3",
-        "jest-matcher-utils": "22.0.3",
-        "jest-message-util": "22.0.3",
-        "jest-snapshot": "22.0.3",
+        "is-generator-fn": "1.0.0",
+        "jest-diff": "22.1.0",
+        "jest-matcher-utils": "22.1.0",
+        "jest-message-util": "22.1.0",
+        "jest-snapshot": "22.1.0",
         "source-map-support": "0.5.0"
       },
       "dependencies": {
@@ -3323,24 +3339,23 @@
       }
     },
     "jest-leak-detector": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.0.3.tgz",
-      "integrity": "sha512-xyVdAmcG8M3jWtVeadDUU6MAHLBrjkP4clz2UtTZ1gpe5bRLk27VjQOpzTwK20MkV/6iZQhSuRVuzHS5kD0HpA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-22.1.0.tgz",
+      "integrity": "sha512-8QsCWkncWAqdvrXN4yXQp9vgWF6CT3RkRey+d06SIHX913uXzAJhJdZyo6eE+uHVYMxUbxqW93npbUFhAR0YxA==",
       "dev": true,
       "requires": {
-        "pretty-format": "22.0.3",
-        "weak": "1.0.1"
+        "pretty-format": "22.1.0"
       }
     },
     "jest-matcher-utils": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.0.3.tgz",
-      "integrity": "sha512-FJbKpCR3K7YYE/Pnvy5OrLFgPEswpYWIfVtdwT2NC6pBARbYGX39KF3bTxS9yg2mv0YL2zHe3UbwzFsi9nFpVA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.1.0.tgz",
+      "integrity": "sha512-Zn1OD9wVjILOdvRxgAnqiCN36OX6KJx+P2FHN+3lzQ0omG2N2OAguxE1QXuJJneG2yndlkXjekXFP254c0cSpw==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-get-type": "22.0.3",
-        "pretty-format": "22.0.3"
+        "jest-get-type": "22.1.0",
+        "pretty-format": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3375,12 +3390,12 @@
       }
     },
     "jest-message-util": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.0.3.tgz",
-      "integrity": "sha512-AVBdCx7Oj5wBpMOH089lx7Zgwpdz9HbReA82HuVAlIT4kEQRvCy6Sl9yVWDGJwHTgB/OYQGkgmbv/P/K8TkWNw==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-22.1.0.tgz",
+      "integrity": "sha512-kftcoawOeOVUGuGWmMupJt7FGLK1pqOrh02FlJwtImmPGZ2yTWCTx2D+N/g95qD2jCbQ/ntH1goBixhAIIxL+g==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.36",
+        "@babel/code-frame": "7.0.0-beta.37",
         "chalk": "2.3.0",
         "micromatch": "2.3.11",
         "slash": "1.0.0",
@@ -3419,21 +3434,21 @@
       }
     },
     "jest-mock": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.0.3.tgz",
-      "integrity": "sha512-donODXcDG03EAEavc9xfJ7fBF/LNVjoZYkmj9DLrQ1B9YcT6wh8Xx7IYg25b8V/8F/eXPMAE0KK5q6Fqe6yAeg==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-22.1.0.tgz",
+      "integrity": "sha512-gL3/C8ds6e1PWiOTsV7sIejPP/ECYQgDbwMzbNCc+ZFPuPH3EpwsVLGmQqPK6okgnDagimbbQnss3kPJ8HCMtA==",
       "dev": true
     },
     "jest-regex-util": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.0.3.tgz",
-      "integrity": "sha512-mplC9chiAotES3ClzNhy0SJcfHB2DivooKJZW+2hDdvP8LLB+OUI+D6bJd7sncbKUsyFcmblEvpm/zz/hef7HA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-22.1.0.tgz",
+      "integrity": "sha512-on0LqVS6Xeh69sw3d1RukVnur+lVOl3zkmb0Q54FHj9wHoq6dbtWqb3TSlnVUyx36hqjJhjgs/QLqs07Bzu72Q==",
       "dev": true
     },
     "jest-resolve": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.0.4.tgz",
-      "integrity": "sha512-yoxHsX4MTT2Ra/dFia9VCunzsA/4jMBENMmLjREIUkCIP1edk/PZUOGVVf680Gw04CtmT5stETylcbmbL7hJBw==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-22.1.0.tgz",
+      "integrity": "sha512-hp4Od9YNEv3A/xNN5pPlNjMuisdZyg3u+XAZOqnGxWPVqnbjvEZ25U2HmYM0eLhOzVTHAAsNnAA8HWDzY1Cwjw==",
       "dev": true,
       "requires": {
         "browser-resolve": "1.11.2",
@@ -3472,56 +3487,58 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.0.3.tgz",
-      "integrity": "sha512-u9MUNJIa9GJ0YFhvM0+Scr4tyX84nC42d3w18Cly1doY7pTT+9momm+TncpuDlFyB2aNmS8SfdEbiLr1e6tBwg==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-22.1.0.tgz",
+      "integrity": "sha512-76Ll61bD/Sus8wK8d+lw891EtiBJGJkWG8OuVDTEX0z3z2+jPujvQqSB2eQ+kCHyCsRwJ2PSjhn3UHqae/oEtA==",
       "dev": true,
       "requires": {
-        "jest-regex-util": "22.0.3"
+        "jest-regex-util": "22.1.0"
       }
     },
     "jest-runner": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.0.4.tgz",
-      "integrity": "sha512-srBkbqmiSB+jzSaG652fmi3kS6rV6wS/4fOG8dxxBg3dCqNQcM2/L3TI3ZK0SwIAcdGJh5Gybs8aDboT8K9Cdw==",
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-22.1.1.tgz",
+      "integrity": "sha512-SWx2trb5t3HHJegN8m7f8puHpl4XPyGFvdgmPZ74reNgvQVR9bJL3FmJn2/XTYtVLeaqqEP1xpC2shxCqJhBMA==",
       "dev": true,
       "requires": {
-        "jest-config": "22.0.4",
-        "jest-docblock": "22.0.3",
-        "jest-haste-map": "22.0.3",
-        "jest-jasmine2": "22.0.4",
-        "jest-leak-detector": "22.0.3",
-        "jest-message-util": "22.0.3",
-        "jest-runtime": "22.0.4",
-        "jest-util": "22.0.4",
-        "jest-worker": "22.0.3",
+        "exit": "0.1.2",
+        "jest-config": "22.1.1",
+        "jest-docblock": "22.1.0",
+        "jest-haste-map": "22.1.0",
+        "jest-jasmine2": "22.1.1",
+        "jest-leak-detector": "22.1.0",
+        "jest-message-util": "22.1.0",
+        "jest-runtime": "22.1.1",
+        "jest-util": "22.1.0",
+        "jest-worker": "22.1.0",
         "throat": "4.1.0"
       }
     },
     "jest-runtime": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.0.4.tgz",
-      "integrity": "sha512-+7uEwf/4f8k1E/eViyGK6/M5yA4O3f6TdWViuqF9MV7vXwG2OVJu8YEZa5239nEnHJiwinXp4eZXX+HB4pQRPg==",
+      "version": "22.1.1",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-22.1.1.tgz",
+      "integrity": "sha512-u7vtAciqpdzaNWxGp12XVdCs2FjM/MdoxELdujcQz1VdLiJ3LE7voiVCxfm/gdram/rhwTHeS8BWzXT8IyXjBg==",
       "dev": true,
       "requires": {
         "babel-core": "6.26.0",
-        "babel-jest": "22.0.4",
+        "babel-jest": "22.1.0",
         "babel-plugin-istanbul": "4.1.5",
         "chalk": "2.3.0",
         "convert-source-map": "1.5.1",
+        "exit": "0.1.2",
         "graceful-fs": "4.1.11",
-        "jest-config": "22.0.4",
-        "jest-haste-map": "22.0.3",
-        "jest-regex-util": "22.0.3",
-        "jest-resolve": "22.0.4",
-        "jest-util": "22.0.4",
+        "jest-config": "22.1.1",
+        "jest-haste-map": "22.1.0",
+        "jest-regex-util": "22.1.0",
+        "jest-resolve": "22.1.0",
+        "jest-util": "22.1.0",
         "json-stable-stringify": "1.0.1",
         "micromatch": "2.3.11",
         "realpath-native": "1.0.0",
         "slash": "1.0.0",
         "strip-bom": "3.0.0",
         "write-file-atomic": "2.3.0",
-        "yargs": "10.0.3"
+        "yargs": "10.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3534,28 +3551,28 @@
           }
         },
         "babel-jest": {
-          "version": "22.0.4",
-          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.0.4.tgz",
-          "integrity": "sha512-/Yt61fUpdFjetYlnpj280BPKEsPnK4mqzxDdo8DybPvrPNrLurbAF/WBjn2nnoi1Hc2Ippsf12/aOp8ys/Vl1A==",
+          "version": "22.1.0",
+          "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-22.1.0.tgz",
+          "integrity": "sha512-5pKRFTlDr+x1JESNRd5leqvxEJk3dRwVvIXikB6Lr4BWZbBppk1Wp+BLUzxWL8tM+EYGLCWgfqkD35Sft8r8Lw==",
           "dev": true,
           "requires": {
             "babel-plugin-istanbul": "4.1.5",
-            "babel-preset-jest": "22.0.3"
+            "babel-preset-jest": "22.1.0"
           }
         },
         "babel-plugin-jest-hoist": {
-          "version": "22.0.3",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.0.3.tgz",
-          "integrity": "sha512-Z0pOZFs0xDctwF0bPEKrnAzvbbgDi2vDFbQ0EdofnLI2bOa3P1H66gNLb2vMJJaa00VDjfiGhIocsHvBkqtyEQ==",
+          "version": "22.1.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.1.0.tgz",
+          "integrity": "sha512-Og5sjbOZc4XUI3njqwYhS6WLTlHQUJ/y5+dOqmst8eHrozYZgT4OMzAaYaxhk75c2fBVYwn7+mNEN97XDO7cOw==",
           "dev": true
         },
         "babel-preset-jest": {
-          "version": "22.0.3",
-          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.0.3.tgz",
-          "integrity": "sha512-FbMMniSMXFvkKldCf+e4Tuol/v3XMaIpIp8xiT1WFlEW3ZapTKDW9YgVt3hqcpZXsIGFf6eUF3Owxom7yFlI8w==",
+          "version": "22.1.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-22.1.0.tgz",
+          "integrity": "sha512-ps2UYz7IQpP2IgZ41tJjUuUDTxJioprHXD8fi9DoycKDGNqB3nAX/ggy1S3plaQd43ktBvMS1FkkyGNoBujFpg==",
           "dev": true,
           "requires": {
-            "babel-plugin-jest-hoist": "22.0.3",
+            "babel-plugin-jest-hoist": "22.1.0",
             "babel-plugin-syntax-object-rest-spread": "6.13.0"
           }
         },
@@ -3588,17 +3605,17 @@
       }
     },
     "jest-snapshot": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.0.3.tgz",
-      "integrity": "sha512-e/a/EvMsY5XROWy4QWX6PvYziuJ8ttD6+QcnbogODWtx2LGhvVQOb7pmqGTo0tL/p0vzFetZA9GlZSh/EfMepg==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-22.1.0.tgz",
+      "integrity": "sha512-g5IqCgAC1TaaocL9xMIE2GLpOPP2li5BPVc2Vsa3ti+e7LMhpooXYcd/ouNqtWDThZD8Tp3jDavyqN0LH6hkPA==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-diff": "22.0.3",
-        "jest-matcher-utils": "22.0.3",
+        "jest-diff": "22.1.0",
+        "jest-matcher-utils": "22.1.0",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
-        "pretty-format": "22.0.3"
+        "pretty-format": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3633,17 +3650,17 @@
       }
     },
     "jest-util": {
-      "version": "22.0.4",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.0.4.tgz",
-      "integrity": "sha512-gNNPtcCFkVh7daKIl3/06eoQ90QXGXCyDOfyZ3IEyTWmHBdX3GvklcOtyGcdOvrYEubaZTfMcMKmEeo/6sRTog==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-22.1.0.tgz",
+      "integrity": "sha512-/IVHOZa7T3sBjzfTKps8QSYf3BS6ugT4fB+612WEjllSTX1fjZNH3TI001TuEhoSz6zLD/BPeteSNCFPHS2O0g==",
       "dev": true,
       "requires": {
         "callsites": "2.0.0",
         "chalk": "2.3.0",
         "graceful-fs": "4.1.11",
-        "is-ci": "1.0.10",
-        "jest-message-util": "22.0.3",
-        "jest-validate": "22.0.3",
+        "is-ci": "1.1.0",
+        "jest-message-util": "22.1.0",
+        "jest-validate": "22.1.0",
         "mkdirp": "0.5.1"
       },
       "dependencies": {
@@ -3679,15 +3696,15 @@
       }
     },
     "jest-validate": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.0.3.tgz",
-      "integrity": "sha512-GmlLmPCtrSQ3iB4A1uxcfjawaaQnwESCDcUg5tMxJKeBbmPdcWPAb6EWzvANxULPUV7hfPKLwg4xIPpi7cx1/g==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-22.1.0.tgz",
+      "integrity": "sha512-v9QKiQksA8e0LXRYBhI6c3vuvYyLAm95kR4SVFGj0l2zgzAG3VNT6qpUAxntna6ERf5jydzzmSpOzLpCJYCUvg==",
       "dev": true,
       "requires": {
         "chalk": "2.3.0",
-        "jest-get-type": "22.0.3",
+        "jest-get-type": "22.1.0",
         "leven": "2.1.0",
-        "pretty-format": "22.0.3"
+        "pretty-format": "22.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3722,9 +3739,9 @@
       }
     },
     "jest-worker": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.0.3.tgz",
-      "integrity": "sha512-fPdCTnogFQiR0CP6whEsIly2RfcHxvalqyLjhui6qa1SnOmHiX7L8k4Umo8CBIp5ndWY0+ej1o7OTE5MlzPabg==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-22.1.0.tgz",
+      "integrity": "sha512-ezLueYAQowk5N6g2J7bNZfq4NWZvMNB5Qd24EmOZLcM5SXTdiFvxykZIoNiMj9C98cCbPaojX8tfR7b1LJwNig==",
       "dev": true,
       "requires": {
         "merge-stream": "1.0.1"
@@ -3773,7 +3790,7 @@
         "left-pad": "1.2.0",
         "nwmatcher": "1.4.3",
         "parse5": "3.0.3",
-        "pn": "1.0.0",
+        "pn": "1.1.0",
         "request": "2.83.0",
         "request-promise-native": "1.0.5",
         "sax": "1.2.4",
@@ -4082,9 +4099,9 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
-      "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+      "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
       "dev": true,
       "requires": {
         "growly": "1.3.0",
@@ -4285,7 +4302,7 @@
       "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
       "dev": true,
       "requires": {
-        "@types/node": "8.5.2"
+        "@types/node": "9.3.0"
       }
     },
     "path-exists": {
@@ -4352,10 +4369,19 @@
         "pinkie": "2.0.4"
       }
     },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0"
+      }
+    },
     "pn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/pn/-/pn-1.0.0.tgz",
-      "integrity": "sha1-HPWjCw2AbNGPiPxBprXUrWFbO6k=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
     "prelude-ls": {
@@ -4371,9 +4397,9 @@
       "dev": true
     },
     "pretty-format": {
-      "version": "22.0.3",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.0.3.tgz",
-      "integrity": "sha512-qXbDFJ2/Kk3HFIaLdOblbsCKQ09kZu4MKbXB+m/EaqD7PZ/wXe2XcRREmQleMh4wmerxlma6eJTh3nxCXYUmmA==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.1.0.tgz",
+      "integrity": "sha512-0HHR5hCmjDGU4sez3w5zRDAAwn7V0vT4SgPiYPZ1XDm5sT3Icb+Bh+fsOP3+Y3UwPjMr7TbRj+L7eQyMkPAxAw==",
       "dev": true,
       "requires": {
         "ansi-regex": "3.0.0",
@@ -4695,6 +4721,21 @@
       "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
       "dev": true
     },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "3.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -4915,12 +4956,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "strip-ansi": {
@@ -5177,17 +5212,6 @@
         }
       }
     },
-    "weak": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/weak/-/weak-1.0.1.tgz",
-      "integrity": "sha1-q5mqswcGlZqgIAy4z1RbucszuZ4=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.8.0"
-      }
-    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -5252,6 +5276,15 @@
         "strip-ansi": "3.0.1"
       },
       "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -5301,12 +5334,12 @@
       "dev": true
     },
     "yargs": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.0.3.tgz",
-      "integrity": "sha512-DqBpQ8NAUX4GyPP/ijDGHsJya4tYqLQrjPr95HNsr1YwL3+daCfvBwg7+gIC6IdJhR2kATh3hb61vjzMWEtjdw==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-10.1.1.tgz",
+      "integrity": "sha512-7uRL1HZdCbc1QTP+X8mehOPuCYKC/XTaqAPj7gABLfTt6pgLyVRn3QVte4qhtilZouWCvqd1kipgMKl5tKsFiw==",
       "dev": true,
       "requires": {
-        "cliui": "3.2.0",
+        "cliui": "4.0.0",
         "decamelize": "1.2.0",
         "find-up": "2.1.0",
         "get-caller-file": "1.0.2",
@@ -5320,28 +5353,30 @@
         "yargs-parser": "8.1.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
             "wrap-ansi": "2.1.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
-            }
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "private": true,
-  "scripts": {
-    "test": "jest",
-    "coverage": "jest --coverage",
-    "test-watch": "jest --watchAll"
-  },
-  "license": "MIT",
-  "devDependencies": {
-    "babel-core": "^6.26.0",
-    "babel-preset-env": "^1.6.1",
-    "jest": "^22.0.4",
-    "jest-fable-preprocessor": "^1.3.3"
-  }
+    "private": true,
+    "scripts": {
+        "test": "jest",
+        "coverage": "jest --coverage",
+        "test-watch": "jest --watchAll"
+    },
+    "license": "MIT",
+    "devDependencies": {
+        "babel-core": "^6.26.0",
+        "babel-preset-env": "^1.6.1",
+        "jest": "^22.1.1",
+        "jest-fable-preprocessor": "^1.3.3"
+    }
 }

--- a/test/__snapshots__/Stream.Test.fs.snap
+++ b/test/__snapshots__/Stream.Test.fs.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should handle multiple errors in a single chunk 1`] = `
+Object {
+  "Test": "bla",
+}
+`;
+
+exports[`should handle multiple errors in a single chunk 2`] = `[SyntaxError: Unexpected end of JSON input]`;
+
+exports[`should handle multiple errors in a single chunk 3`] = `[SyntaxError: Unexpected token } in JSON at position 5]`;
+
+exports[`should handle multiple errors in a single chunk 4`] = `
+Object {
+  "Test2": "bla",
+}
+`;


### PR DESCRIPTION
  - Add a `streams` computation expression. This allows for easier
creation of finite source streams during testing, though it is put in
object mode, so use caution if performance is critical.
  - Fix a bug where `LineDelimitedJson` stream can call the transform
callback twice, causing an error. Instead of this, change transform so
we never call the callback with data, and instead require transform and
flush to return a `Result`.
  - Allow transform stream to emit multiple errors for a single chunk.
    This is important for `LineDelimitedJson`.

Signed-off-by: Joe Grund <joe.grund@intel.com>